### PR TITLE
Make process name check case insensitive

### DIFF
--- a/FFXIVTool/MainWindow.xaml.cs
+++ b/FFXIVTool/MainWindow.xaml.cs
@@ -68,7 +68,7 @@ namespace FFXIVTool
             Processcheck = 0;
             foreach (Process theprocess in processlist)
             {
-                if (theprocess.ProcessName.Contains("ffxiv_dx11"))
+                if (theprocess.ProcessName.ToLower().Contains("ffxiv_dx11"))
                 {
                     Processcheck++;
                     GameList.Add(new ProcessLooker.Game() { ProcessName = theprocess.ProcessName, ID = theprocess.Id, StartTime = theprocess.StartTime, AppIcon = IconToImageSource(System.Drawing.Icon.ExtractAssociatedIcon(theprocess.MainModule.FileName)) });


### PR DESCRIPTION
In some environments, this process name registers itself as FFXIV_DX11
instead of ffxiv_dx11, such as when the game is launched remotely from a
network share. Make the check case insensitive to accommodate for this
case.